### PR TITLE
Create a Vagrant project to deploy OpenFaas in a local environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,91 @@
+# Created by https://www.toptal.com/developers/gitignore/api/ruby,vagrant,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=ruby,vagrant,visualstudiocode
+
+### OpenFaaS ###
+template
+build
+
+### Ruby ###
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+# Ignore Byebug command history file.
+.byebug_history
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# Used by RuboCop. Remote config files pulled in from inherit_from directive.
+# .rubocop-https?--*
+
+### Vagrant ###
+# General
+.vagrant/
+
+# Log files (if you are creating logs in debug mode, uncomment this)
+# *.log
+
+### Vagrant Patch ###
+*.box
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# End of https://www.toptal.com/developers/gitignore/api/ruby,vagrant,visualstudiocode

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,1 @@
+source 'https://rubygems.org'

--- a/README.md
+++ b/README.md
@@ -4,6 +4,166 @@ OpenFaaS in your local environment.
 
 ## Prerequisites
 
-- Virtualbox
-- Vagrant
-- faas-cli
+- [Virtualbox](https://www.virtualbox.org) - A a free and open-source hosted hypervisor for x86 virtualization.
+- [Vagrant](https://github.com/hashicorp/vagrant) - A tool for building and distributing development environments.
+- [faas-cli](https://github.com/openfaas/faas-cli) - Official CLI for OpenFaaS.
+
+## Overview
+
+The Vagrantfile will create a virtual machine running Ubuntu 18.04 LTS (Bionic Beaver) in Virtualbox. It will install OpenFaaS using the [faasd](https://github.com/openfaas/faasd) provider for a single node.
+
+## Usage
+
+Run the following command to deploy openfaas:
+```sh
+$ vagrant up
+```
+
+You will be prompted with a message asking to select a Docker container registry (optional):
+```sh
+Choose a Container Registry Server:
+1) Docker (docker.io)
+2) GitHub (ghcr.io)
+3) Quay   (quay.io)
+4) Other registry # <- provide your own url
+5) Skip # <- skip if you want to keep your docker images locally
+0) Quit # <- exit the script, you will have to destroy the VM afterwards
+Enter selection [0-5]: 
+```
+
+If you haven't selected `Skip` or `Quit`, you will be asked for your credentials:
+```
+Virtual machine needs your credentials for the container registry ghcr.io
+Username: dysonfrost
+Password:
+```
+
+When the VM is ready, vagrant will display some information:
+```
+### Vagrant Box provisioned! ###
+------------------------------------------------------
+Local OpenFaas is ready
+
+URLS:
+ * OpenFaaS - http://192.168.50.2:8080
+
+OpenFaaS credentials:
+ * username: admin
+ * password: <generated_password>
+
+Login with faas-cli:
+ $ export OPENFAAS_URL=http://192.168.50.2:8080 # From Host
+ $ faas-cli login -u admin --password <generated_password>
+
+------------------------------------------------------
+```
+
+If somehow you need to retrieve your generated password:
+```sh
+$ vagrant ssh
+vagrant@openfaas:~$ sudo cat /var/lib/faasd/secrets/basic-auth-password
+```
+
+## CLI
+
+OpenFaas can be accessed from both the host and the guest VM, once logged in (see information above) you can build a new function.
+
+### List templates from store
+```sh
+$ faas-cli template store ls
+```
+
+### Pull templates from store
+```sh
+# faas-cli template store pull <template>
+$ faas-cli template store pull dockerfile
+```
+### Download templates from specified git repo
+
+```sh
+$ faas-cli template pull <repository_url>
+```
+
+### Create a new function
+```sh
+# faas-cli new <function> --lang=<template>
+$ faas-cli new hello-world --lang=dockerfile
+```
+
+### Checkout the YAML file
+```yml
+version: 1.0
+provider:
+  name: openfaas
+  gateway: http://192.168.50.2:8080
+functions:
+  hello-world:
+    lang: dockerfile
+    handler: ./hello-world
+    image: hello-world:latest
+```
+
+- `gateway` - URL of the gateway (set to localhost if running from VM guest)
+- `lang` - Template associated with the function
+- `handler` - The folder / path to your handler / Dockerfile and any other source code you need
+- `image` - The Docker image name. If you are going to push to a container registry change the prefix of your image - i.e. ghcr.io/dysonfrost/hello-world:latest
+
+### Build a function
+```sh
+# faas-cli build -f <function>.yml
+$ faas-cli build -f hello-world.yml
+```
+_Skip the following steps if you do not intend to use a remote registery to invoke a function._
+### Push a function
+```sh
+# faas-cli push -f <function>.yml
+$ faas-cli push -f hello-world.yml
+```
+
+### Deploy a function
+```sh
+# faas-cli deploy -f <function>.yml
+$ faas-cli deploy -f hello-world.yml
+```
+
+### Build, push and deploy a function
+```sh
+# faas-cli up -f <function>.yml
+$ faas-cli up -f hello-world.yml
+```
+
+### Invoke a function
+```sh
+# faas-cli invoke <function>
+$ faas-cli invoke hello-world
+
+# Using cURL
+curl http://192.168.50.2:8080/function/hello-world
+```
+
+### Invoke a function with some data
+```sh
+# echo "<some-data>" | faas-cli invoke <function>
+$ echo "Hi there!" | faas-cli invoke hello-world
+
+# Using cURL
+curl http://192.168.50.2:8080/function/hello-world -d "Hi there!"
+```
+
+## UI
+
+A user interface is available at `http://192.168.50.2:8080/ui/`  
+You can Deploy and Invoke new functions from there.
+
+## Uninstall
+
+To delete the virtual machine, run the following command:
+```sh
+$ vagrant destroy -f
+```
+
+## References
+- https://github.com/openfaas/faas
+- https://github.com/openfaas/faasd
+- https://docs.openfaas.com
+- https://blog.alexellis.io/tag/openfaas

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,24 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+registry_rb = './lib/registry.rb'
+load registry_rb
+
+Vagrant.configure("2") do |config|
+
+  config.vm.box = "hashicorp/bionic64"
+  config.vm.network "private_network", ip: "192.168.50.2"
+  config.vm.provider "virtualbox" do |vb, override|
+    vb.gui = false
+    vb.memory = "2048"
+    vb.cpus = 2
+  end
+
+  config.vm.define "faas" do |faas|
+    faas.vm.hostname = "openfaas"
+    faas.vm.provision "faas", type: "shell",
+      path: "scripts/provision.sh",
+      env: {"CR_SERVER" => Registry.new, "CR_USER" => Username.new, "CR_PAT" => Password.new},
+      privileged: false
+  end
+end

--- a/lib/registry.rb
+++ b/lib/registry.rb
@@ -1,0 +1,107 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+class Registry
+  def to_s
+    puts <<-CHOICES
+    Choose a Container Registry Server:
+    1) Docker (docker.io)
+    2) GitHub (ghcr.io)
+    3) Quay   (quay.io)
+    4) Other registry
+    5) Skip
+    0) Quit
+    CHOICES
+    print "Enter selection [0-5]: "
+    choice = STDIN.gets.chomp
+
+    case choice
+    when "0"
+      quit_selection
+    when "1"
+      registry_docker
+    when "2"
+      registry_github
+    when "3"
+      registry_quay
+    when "4"
+      registry_other
+    when "5"
+      skip_selection
+    else
+      try_again
+    end
+  end
+
+  def try_again
+    puts "\nInvalid input.\n\n"
+    to_s
+  end
+
+  def quit_selection
+    puts "\nBye!\nDon't forget to destroy the Guest VM..."
+    exit
+  end
+
+  def skip_selection
+    puts "Selection skipped...\n"
+    @@reg_name = nil.to_s
+  end
+
+  def registry_docker
+    puts "Selected registry: Docker"
+    @@reg_name = "https://index.docker.io/v1/"
+  end
+
+  def registry_github
+    puts "Selected registry: GitHub"
+    @@reg_name = "ghcr.io"
+  end
+
+  def registry_quay
+    puts "Selected registry: Quay"
+    @@reg_name = "quay.io"
+  end
+
+  def registry_other
+    print "Please specify a valid Docker registry: "
+    @@reg_name = STDIN.gets.chomp
+  end
+
+  def server
+    @@reg_name
+  end
+end
+
+class Username
+  def to_s
+    r = Registry.new
+    server = r.server
+    if server != nil.to_s
+      puts "\nVirtual machine needs your credentials for the container registry #{server}"
+      print "Username: "
+      user = STDIN.gets.chomp
+    else
+      user = nil.to_s
+    end
+  end
+end
+
+class Password
+  def to_s
+    r = Registry.new
+    server = r.server
+    if server != nil.to_s
+      begin
+        system 'stty -echo'
+        print "Password: "
+        pass = URI.escape(STDIN.gets.chomp)
+      ensure
+        system 'stty echo'
+      end
+      pass
+    else
+      pass = nil.to_s
+    end
+  end
+end

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -e
+
+function display_message {
+  cat <<EOF
+
+### Vagrant Box provisioned! ###
+------------------------------------------------------
+Local OpenFaas is ready
+
+URLS:
+ * OpenFaaS - http://192.168.50.2:8080
+
+OpenFaaS credentials:
+ * username: admin
+ * password: $(echo "$FAASD_PASSWORD")
+
+Login with faas-cli from your host:
+ $ export OPENFAAS_URL=http://192.168.50.2:8080
+ $ faas-cli login -u admin --password $(echo "$FAASD_PASSWORD")
+
+------------------------------------------------------
+EOF
+}
+
+function install_faasd {
+  git clone https://github.com/openfaas/faasd --depth=1
+  cd faasd
+  ./hack/install.sh
+  FAASD_PASSWORD=$(sudo cat /var/lib/faasd/secrets/basic-auth-password)
+  journalctl -f -u faasd >> /tmp/faasd.log &
+}
+
+function faasd_proxy_check {
+  sudo systemctl is-active --quiet faasd &&
+    tail -f /tmp/faasd.log | sed '/Proxy from: 0.0.0.0:8080/ q'
+}
+
+function registry_login {
+  local base_url="https://raw.githubusercontent.com/openfaas-incubator"
+
+  curl -sLSf "${base_url}/ofc-bootstrap/master/get.sh" | sudo sh
+  ofc-bootstrap registry-login --server "$1" --username "$2" --password "$3"
+  sudo mkdir -p /var/lib/faasd/.docker
+  sudo cp credentials/config.json /var/lib/faasd/.docker/config.json
+}
+
+install_faasd
+faasd_proxy_check
+[[ -z $CR_SERVER ]] || registry_login "$CR_SERVER" "$CR_USER" "$CR_PAT"
+display_message


### PR DESCRIPTION
This PR to launch the project.

Run the following command to deploy openfaas:
```sh
$ vagrant up
```

You will be prompted with a message asking to select a Docker container registry (optional):
```sh
Choose a Container Registry Server:
1) Docker (docker.io)
2) GitHub (ghcr.io)
3) Quay   (quay.io)
4) Other registry # <- provide your own url
5) Skip # <- skip if you want to keep your docker images locally
0) Quit # <- exit the script, you will have to destroy the VM afterwards
Enter selection [0-5]: 
```

If you haven't selected `Skip` or `Quit`, you will be asked for your credentials:
```
Virtual machine needs your credentials for the container registry ghcr.io
Username: dysonfrost
Password:
```

You will be prompted with instructions when the VM is ready:
```
### Vagrant Box provisioned! ###
------------------------------------------------------
Local OpenFaas is ready

URLS:
 * OpenFaaS - http://192.168.50.2:8080

OpenFaaS credentials:
 * username: admin
 * password: mWvaQ2rMMvQKCoayOpsoi0rdFdZi0jZdqdeQbc69iis5zQj5Ekf6xX7VLV5maIB

Login with faas-cli from your host:
 $ export OPENFAAS_URL=http://192.168.50.2:8080
 $ faas-cli login -u admin --password mWvaQ2rMMvQKCoayOpsoi0rdFdZi0jZdqdeQbc69iis5zQj5Ekf6xX7VLV5maIB

------------------------------------------------------
```
